### PR TITLE
Use Debian maintenance account if it exists.

### DIFF
--- a/mysql_maint.sh
+++ b/mysql_maint.sh
@@ -47,6 +47,12 @@ DB_PASS=admin
 DB_PORT=3306
 DB_SOCKET=
 
+# If we're running on a Debian family we can use the maintenance account.
+if [[ -f /etc/mysql/debian.cnf ]]; then
+    DB_USER=$(sudo grep user /etc/mysql/debian.cnf | head -n1 | sed -r 's/^.+=\s*//')
+    DB_PASS=$(sudo grep password /etc/mysql/debian.cnf | head -n1 | sed -r 's/^.+=\s*//')
+fi
+
 # Weekly backup day
 # (result of 'date %u')
 DOW='7'


### PR DESCRIPTION
Just a small addition to import the Debian maintenance account as long as /etc/mysql/debian.cnf exists.
